### PR TITLE
Enable the "Load Account" File Upload to work for Firefox

### DIFF
--- a/packages/webapp/src/views/PoolView/sections/AccountSection/AccountCard.tsx
+++ b/packages/webapp/src/views/PoolView/sections/AccountSection/AccountCard.tsx
@@ -62,7 +62,7 @@ export const AccountCard = ({ className }: { className: string }) => {
     [importKeys]
   )
 
-  const { getRootProps } = useDropzone({ onDrop })
+  const { getInputProps, getRootProps } = useDropzone({ onDrop })
 
   return (
     <Card className={cn("", className)}>
@@ -133,6 +133,7 @@ export const AccountCard = ({ className }: { className: string }) => {
       <CardContent className="space-y-2">
         <div className="grid grid-cols-1 gap-4 tablet:grid-cols-3 2xl:grid-cols-3 justify-around">
           <div className="flex justify-center mt-10">
+            <input type="file" {...getInputProps()} />
             <IconButton {...getRootProps()} icon={<Upload />} disabled={false}>
               Import Keys
             </IconButton>


### PR DESCRIPTION
![Screenshot from 2024-08-14 10-17-43](https://github.com/user-attachments/assets/8fa709ea-d77d-48fa-821c-1fd4b3a14bc4)



While I was using the privacy pool app in this repo, I noticed that the key upload functionality wasn't working on the Firefox browser that I was using, so I made this PR to remedy that.

After investigating the issue, I saw that this is a commonly encountered issue for the react-dropzone component that we are using. There is a github issue and discussion here: https://github.com/react-dropzone/react-dropzone/issues/1294#issuecomment-1557224171. 

The problem is that Firefox requires an `<input>` element to be added to the dropzone in order to open the file upload dialog. This is needed because, unlike other browsers, Firefox does not fully support the File System access API that the current implementation defaults to. Adding the element fixes this issue.

This PR implements this change.